### PR TITLE
Update to React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "immutable": "^3.7.4",
     "keycode": "^2.1.0",
     "lodash": "^3.9.3",
-    "react": "^0.13.3",
+    "react": "^0.14.2",
+    "react-dom": "^0.14.2",
     "react-center-component": "^1.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 /**
  * dynamics.js is an animation library
@@ -7,6 +8,8 @@ import dynamics from 'dynamics.js';
 import keycode from 'keycode';
 import centerComponent from 'react-center-component';
 import EventStack from 'active-event-stack';
+
+var renderSubtreeIntoContainer = require("react-dom").unstable_renderSubtreeIntoContainer;
 
 export class ModalPortal extends React.Component {
 	_target = null // HTMLElement, a div that is appended to the body
@@ -30,18 +33,18 @@ export class ModalPortal extends React.Component {
 		this._target = document.body.appendChild(document.createElement('div'));
 
 		// Mount a component on that div
-		this._component = React.render(this.props.children, this._target);
+		this._component = renderSubtreeIntoContainer(this, this.props.children, this._target);
 	}
 	componentDidUpdate = () => {
 		// When the child component updates, we have to make sure the content rendered to the DOM is updated to
-		this._component = React.render(this.props.children, this._target);
+		this._component = renderSubtreeIntoContainer(this, this.props.children, this._target);
 	}
 	componentWillUnmount = () => {
 		EventStack.removeListenable(this.eventToken);
 
 		const done = () => {
 			// Remove the node and clean up after the target
-			React.unmountComponentAtNode(this._target);
+			ReactDOM.unmountComponentAtNode(this._target);
 			document.body.removeChild(this._target);
 		}
 


### PR DESCRIPTION
This upgrades the dialog to use renderSubtreeIntoContainer, which based on other modal libraries, appears to be the appropriate way to do this now. The returned object appears to behave similarly to that of React.render, so all of the previous introspection of the object works.
