### PR TITLE
Make modal width auto

### DIFF
--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -40,7 +40,6 @@ export default class ModalDialog extends React.Component {
   static propTypes = {
     onClose: PropTypes.func, // required for the close button
     className: PropTypes.string, // css class in addition to .ReactModalDialog
-    width: PropTypes.number, // width
     topOffset: PropTypes.number, // injected by @centerComponent
     leftOffset: PropTypes.number, // injected by @centerComponent
     margin: PropTypes.number.isRequired, // the margin around the dialog
@@ -50,7 +49,7 @@ export default class ModalDialog extends React.Component {
     sheet: PropTypes.object,
   }
   static defaultProps = {
-    width: 500,
+    width: 'auto',
     margin: 20,
   }
   componentWillMount = () => {

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -40,6 +40,7 @@ export default class ModalDialog extends React.Component {
   static propTypes = {
     onClose: PropTypes.func, // required for the close button
     className: PropTypes.string, // css class in addition to .ReactModalDialog
+    width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // width
     topOffset: PropTypes.number, // injected by @centerComponent
     leftOffset: PropTypes.number, // injected by @centerComponent
     margin: PropTypes.number.isRequired, // the margin around the dialog


### PR DESCRIPTION
This is actually the way that bootstrap's modal works and I think it makes the most sense. This way the modal will be responsive and work as expected in mobile devices. If you want to override the width you are also welcome to do that through the styles, and you can use media queries in javascript to make it look good in different resolutions. For your consideration!
