### PR TITLE
Wrap in UMD modules so AMD-reliant people can use this too

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "modules": "umd",
   "stage": 0
 }


### PR DESCRIPTION
My work environment requires (pardon the pun) us to use a requireJS-style AMD loader.  Using UMD should allow CJS and AMD people to work with the same code.
