### PR TITLE
Fix invalid import syntax

### DIFF
--- a/src/useSheet.js
+++ b/src/useSheet.js
@@ -1,11 +1,11 @@
-import {create} from 'jss';
+import jssClass from 'jss';
 import reactJss from 'react-jss';
 import vendorPrefixer from 'jss-vendor-prefixer';
 import jssPx from 'jss-px';
 import jssCamelCase from 'jss-camel-case';
 import jssNested from 'jss-nested';
 
-const jss = create();
+const jss = jssClass.create();
 jss.use(vendorPrefixer());
 jss.use(jssPx());
 jss.use(jssCamelCase());


### PR DESCRIPTION
The import syntax here is invalid by spec I believe, but babel allowed it by translating it to a default import + object destructure, in absence of any named exports.

However, JSS has [added named exports](https://github.com/jsstyles/jss/commit/5e5515eab7d18f21d7350f99fae2cfb8e820ec50#diff-1fdf421c05c1140f6d71444ea2b27638R14) when going from v3.3.0 to v3.4.0. This is technically a backwards compatible change, so the minor version bump is fine. However, the behavior is breaking in react-modal-dialog when combined with the way babel works. Now that JSS has named exports, `import {create} from 'jss'` tries to find and bind to the `create` export which doesn't exist, rather than destructuring the default `Jss` object into the `create` variable. Therefore, builds that have installed the latest JSS (v3.4.0) will see this or similar:

```
TypeError: (0 , _jss.create) is not a function
    at Object.<anonymous> (/usr/src/app/node_modules/react-modal-dialog/lib/useSheet.js:31:27)
```

This fixes the issue by restoring the behavior in a way that is compatible with default exports. Alternatively, this could also be fixed by just using `new` instead of `create` because that's all `create` does anyway.
