### PR TITLE
for ios modal background isn't clicked

### DIFF
--- a/src/ModalBackground.js
+++ b/src/ModalBackground.js
@@ -70,6 +70,7 @@ export default class ModalBackground extends React.Component {
       width: '100%',
       transition: `opacity ${this.props.duration / 1000}s`,
       WebkitTransition: `opacity ${this.props.duration / 1000}s`,
+      backgroundColor: 'transparent',
     };
 
     const style = {
@@ -83,7 +84,7 @@ export default class ModalBackground extends React.Component {
 
     return <div style={style}>
       <div style={overlayStyle}/>
-      <div style={containerStyle}>{this.getChild()}</div>
+      <button style={containerStyle}>{this.getChild()}</button>
     </div>;
   }
 }


### PR DESCRIPTION
when modal popup background is clicked
it wont't be clicked in ios(iphone, ipad, not macbook)
[ref here](http://stackoverflow.com/questions/4158847/is-there-a-way-to-simulate-key-presses-or-a-click-with-javascript)
#25
