### PR TITLE
Allow to disable default styles

### DIFF
--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -58,9 +58,6 @@ export default class ModalDialog extends React.Component {
     width: 'auto',
     margin: 20,
   }
-  static setUseDefaultStyles(use) {
-    useDefaultStyles = use;
-  }
 
   componentWillMount = () => {
     /**
@@ -196,3 +193,7 @@ export default class ModalDialog extends React.Component {
     </div>;
   };
 }
+
+ModalDialog.setUseDefaultStyles = (use) => {
+  useDefaultStyles = use;
+};

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -8,6 +8,8 @@ import CloseCircle from './CloseCircle';
 import EventStack from 'active-event-stack';
 import keycode from 'keycode';
 
+let useDefaultStyles = true;
+
 @useSheet({
   dialog: {
     boxSizing: 'border-box',
@@ -56,6 +58,10 @@ export default class ModalDialog extends React.Component {
     width: 'auto',
     margin: 20,
   }
+  static setUseDefaultStyles(use) {
+    useDefaultStyles = use;
+  }
+
   componentWillMount = () => {
     /**
      * This is done in the componentWillMount instead of the componentDidMount
@@ -166,7 +172,13 @@ export default class ModalDialog extends React.Component {
       ...style,
     };
 
-    const divClassName = classNames(classes.dialog, className);
+    let divClassName = className;
+    let closeClassName = '';
+
+    if (useDefaultStyles) {
+        divClassName = classNames(classes.dialog, className);
+        closeClassName = classes.closeButton;
+    }
 
     return <div {...rest}
       ref="self"
@@ -175,7 +187,7 @@ export default class ModalDialog extends React.Component {
     >
       {
         onClose ?
-        <a className={classes.closeButton} onClick={onClose}>
+        <a className={closeClassName} onClick={onClose}>
           <CloseCircle diameter={40}/>
         </a> :
         null


### PR DESCRIPTION
I've added an utility to disable the default style of the modal, same as React Tabs: https://github.com/reactjs/react-tabs#styling

I'm happy to modify and add a few lines of docs inside the README if you like this PR.

I'm wondering if we should still have a class for the close button or if we should allow to change (and hide maybe) that element.
