### PR TITLE
Correct exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,5 @@
-import ModalPortal from './ModalPortal';
-import ModalBackground from './ModalBackground';
-import ModalContainer from './ModalContainer';
-import ModalDialog from './ModalDialog';
-import FlexDialog from './FlexDialog';
-
-export default {
-  ModalPortal,
-  ModalBackground,
-  ModalContainer,
-  ModalDialog,
-  FlexDialog,
-};
+export ModalPortal from './ModalPortal';
+export ModalBackground from './ModalBackground';
+export ModalContainer from './ModalContainer';
+export ModalDialog from './ModalDialog';
+export FlexDialog from './FlexDialog';


### PR DESCRIPTION
Instead of exporting as default an object containing pointers to those default imports, export the default exports themselves.

This allows `import * as reactModal from 'react-modal-dialog'`, as well as `import { ModalPortal, /* ... */ } from 'react-modal-dialog'` to actually work correctly with real ES modules.
