### PR TITLE
Add dismissEverywhere and autoDismiss props to ModalDialog

### DIFF
--- a/src/ModalBackground.js
+++ b/src/ModalBackground.js
@@ -58,6 +58,7 @@ export default class ModalBackground extends React.Component {
       width: '100%',
       transition: `opacity ${this.props.duration / 1000}s`,
       WebkitTransition: `opacity ${this.props.duration / 1000}s`,
+      cursor: 'pointer'
     };
 
     const containerStyle = {

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -51,11 +51,13 @@ export default class ModalDialog extends React.Component {
     left: PropTypes.number,
     recenter: PropTypes.func.isRequired,
     top: PropTypes.number,
-    autoDismiss: PropTypes.number // seconds before automatically dismissing dialog
+    autoDismiss: PropTypes.number, // seconds before automatically dismissing dialog
+    dismissEverywhere: PropTypes.bool
   }
   static defaultProps = {
     width: 'auto',
     margin: 20,
+    dismissEverywhere: false
   }
   componentWillMount = () => {
     /**
@@ -104,6 +106,9 @@ export default class ModalDialog extends React.Component {
   };
   didAnimateInAlready = false;
   shouldClickDismiss = (event) => {
+    if (this.props.dismissEverywhere) {
+      return true;
+    }
     const { target } = event;
     // This piece of code isolates targets which are fake clicked by things
     // like file-drop handlers
@@ -156,6 +161,7 @@ export default class ModalDialog extends React.Component {
         children,
         className,
         componentIsLeaving, // eslint-disable-line no-unused-vars, this line is used to remove parameters from rest
+        dismissEverywhere,
         left, // eslint-disable-line no-unused-vars, this line is used to remove parameters from rest
         leftOffset,
         margin,

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -51,6 +51,7 @@ export default class ModalDialog extends React.Component {
     left: PropTypes.number,
     recenter: PropTypes.func.isRequired,
     top: PropTypes.number,
+    autoDismiss: PropTypes.number // seconds before automatically dismissing dialog
   }
   static defaultProps = {
     width: 'auto',
@@ -67,6 +68,17 @@ export default class ModalDialog extends React.Component {
       [ 'keydown', this.handleGlobalKeydown ],
     ]);
   };
+  componentDidMount = () => {
+    if (typeof this.props.autoDismiss === 'number') {
+      setTimeout(
+        function () {
+          if (typeof this.props.onClose === 'function') {
+            this.props.onClose();
+          }
+        }.bind(this),
+      1000 * this.props.autoDismiss);
+    }
+  }
   componentWillReceiveProps = (nextProps) => {
     if (nextProps.topOffset !== null && this.props.topOffset === null) {
       // This means we are getting top information for the first time
@@ -140,6 +152,7 @@ export default class ModalDialog extends React.Component {
   render = () => {
     const {
       props: {
+        autoDismiss,
         children,
         className,
         componentIsLeaving, // eslint-disable-line no-unused-vars, this line is used to remove parameters from rest


### PR DESCRIPTION
- **dismissEverywhere**: a boolean prop that, when true, allows the user to click anywhere on screen to dismiss the modal
- **autoDismiss**: a Number prop that, when set, automatically dismisses the modal after x number of seconds
