### PR TITLE
sending event when onClose is triggered

### DIFF
--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -105,14 +105,14 @@ export default class ModalDialog extends React.Component {
   handleGlobalClick = (event) => {
     if (this.shouldClickDismiss(event)) {
       if (typeof this.props.onClose == 'function') {
-        this.props.onClose();
+        this.props.onClose(event);
       }
     }
   };
   handleGlobalKeydown = (event) => {
     if (keycode(event) === 'esc') {
       if (typeof this.props.onClose == 'function') {
-        this.props.onClose();
+        this.props.onClose(event);
       }
     }
   };


### PR DESCRIPTION
Like mentioned in the Issue #33 Sending the event object when onClose is triggered.
This PR fixes it
