### PR TITLE
Toggle class on body when modal is opened/closed

### DIFF
--- a/src/ModalPortal.js
+++ b/src/ModalPortal.js
@@ -16,6 +16,9 @@ export default class ModalPortal extends React.Component {
 
     // Mount a component on that div
     this._component = renderSubtreeIntoContainer(this, this.props.children, this._target);
+    
+    // Add indicator class to body
+    document.body.classList.toggle('modal-dialog-opened');
   };
   componentDidUpdate = () => {
     // When the child component updates, we have to make sure the content rendered to the DOM is updated to
@@ -45,6 +48,9 @@ export default class ModalPortal extends React.Component {
       // Call completion immediately
       done();
     }
+    
+    // remove indicator class from document body
+    document.body.classList.remove('modal-dialog-opened');
   };
   _target = null; // HTMLElement, a div that is appended to the body
   _component = null; // ReactComponent, which is mounted on the target


### PR DESCRIPTION
To address this issue:
https://github.com/qimingweng/react-modal-dialog/issues/13
And maybe for some other scenarios when we need to tweak things outside of our modal.

Would be also great if you can update npm package.
