### PR TITLE
Fix for unknown prop warning

### DIFF
--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -157,6 +157,7 @@ export default class ModalDialog extends React.Component {
         top, // eslint-disable-line no-unused-vars, this line is used to remove parameters from rest
         topOffset,
         width,
+        dismissOnBackgroundClick,
         ...rest,
       },
     } = this;


### PR DESCRIPTION
Fix for “Warning: Unknown prop `dismissOnBackgroundClick` on <div> tag. Remove this prop from the element.”