### PR TITLE
Update PropTypes for React v15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "keycode": "^2.1.0",
     "lodash": "^3.9.3",
     "narcissus": "^1.0.0",
+    "prop-types": "^15.5.8",
     "react-center-component": "^3.0.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",

--- a/src/CloseCircle.js
+++ b/src/CloseCircle.js
@@ -1,4 +1,5 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 // Done in SVG so we can avoid importing any CSS
 const RECT_WIDTH = 1.5;

--- a/src/FlexDialog.js
+++ b/src/FlexDialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { inject } from 'narcissus';
 

--- a/src/ModalBackground.js
+++ b/src/ModalBackground.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class ModalBackground extends React.Component {
   static propTypes = {

--- a/src/ModalContainer.js
+++ b/src/ModalContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React  from 'react';
+import PropTypes from 'prop-types';
 
 import ModalPortal from './ModalPortal';
 import ModalBackground from './ModalBackground';

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import dynamics from 'dynamics.js';

--- a/src/ModalPortal.js
+++ b/src/ModalPortal.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 // Render into subtree is necessary for parent contexts to transfer over

--- a/src/UnstyledFlexDialog.js
+++ b/src/UnstyledFlexDialog.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import dynamics from 'dynamics.js';
 import CloseCircle from './CloseCircle';


### PR DESCRIPTION
Updated `import React, { PropTypes } from 'react';` to `import PropTypes from 'prop-types';`
and updated React -> v15.5.4

info: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html